### PR TITLE
fix: Same windows 255 fix for tunneling ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ OPTIONS:
    --help, -h                                     show help
 ```
 
+By default it runs `nvim`, but you can run something else with
+
+```sh
+nvrh client open \
+  --local-editor nvim-qt \
+  --local-editor --nofork \
+  --local-editor --server \
+  --local-editor {{SOCKET_PATH}}
+
 ### `:NvrhTunnelPort`
 
 https://github.com/user-attachments/assets/4a8c302e-4e49-4f74-81a3-ac86ba33016a

--- a/README.md
+++ b/README.md
@@ -38,20 +38,11 @@ CATEGORY:
    client
 
 OPTIONS:
-   --use-ports                                                        Use ports instead of sockets. Defaults to true on Windows (default: false) [$NVRH_CLIENT_USE_PORTS]
-   --server-env value [ --server-env value ]                          Environment variables to set on the remote server
-   --local-editor {{SOCKET_PATH}} [ --local-editor {{SOCKET_PATH}} ]  Local editor to use. {{SOCKET_PATH}} will be replaced with the socket path (default: "nvim", "--server", "{{SOCKET_PATH}}", "--remote-ui")
-   --help, -h                                                         show help
-```
-
-By default it runs `nvim`, but you can run something else with
-
-```sh
-nvrh client open \
-  --local-editor nvim-qt \
-  --local-editor --nofork \
-  --local-editor --server \
-  --local-editor {{SOCKET_PATH}}
+   --ssh-path value                               Path to SSH binary. Defaults to ssh on Unix, C:\Windows\System32\OpenSSH\ssh.exe on Windows (default: "ssh") [%NVRH_CLIENT_SSH_PATH%]
+   --use-ports                                    Use ports instead of sockets. Defaults to true on Windows (default: false) [%NVRH_CLIENT_USE_PORTS%]
+   --server-env value [ --server-env value ]      Environment variables to set on the remote server
+   --local-editor value [ --local-editor value ]  Local editor to use. {{SOCKET_PATH}} will be replaced with the socket path (default: "nvim", "--server", "{{SOCKET_PATH}}", "--remote-ui")
+   --help, -h                                     show help
 ```
 
 ### `:NvrhTunnelPort`

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ nvrh client open \
   --local-editor --nofork \
   --local-editor --server \
   --local-editor {{SOCKET_PATH}}
+```
 
 ### `:NvrhTunnelPort`
 

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -47,7 +47,7 @@ var CliClientOpenCommand = cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "ssh-path",
-			Usage:   "Path to SSH binary. Defaults to `ssh` on Unix, `C:\\Windows\\System32\\OpenSSH\\ssh.exe` on Windows",
+			Usage:   "Path to SSH binary. Defaults to ssh on Unix, C:\\Windows\\System32\\OpenSSH\\ssh.exe on Windows",
 			EnvVars: []string{"NVRH_CLIENT_SSH_PATH"},
 			Value:   defaultSshPath(),
 		},
@@ -66,7 +66,7 @@ var CliClientOpenCommand = cli.Command{
 
 		&cli.StringSliceFlag{
 			Name:  "local-editor",
-			Usage: "Local editor to use. `{{SOCKET_PATH}}` will be replaced with the socket path",
+			Usage: "Local editor to use. {{SOCKET_PATH}} will be replaced with the socket path",
 			Value: cli.NewStringSlice("nvim", "--server", "{{SOCKET_PATH}}", "--remote-ui"),
 		},
 	},

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -21,6 +21,14 @@ import (
 	"nvrh/src/ssh_helpers"
 )
 
+func defaultSshPath() string {
+	if runtime.GOOS == "windows" {
+		return "C:\\Windows\\System32\\OpenSSH\\ssh.exe"
+	}
+
+	return "ssh"
+}
+
 var CliClientCommand = cli.Command{
 	Name: "client",
 
@@ -37,6 +45,13 @@ var CliClientOpenCommand = cli.Command{
 	ArgsUsage: "<server> [remote-directory]",
 
 	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "ssh-path",
+			Usage:   "Path to SSH binary. Defaults to `ssh` on Unix, `C:\\Windows\\System32\\OpenSSH\\ssh.exe` on Windows",
+			EnvVars: []string{"NVRH_CLIENT_SSH_PATH"},
+			Value:   defaultSshPath(),
+		},
+
 		&cli.BoolFlag{
 			Name:    "use-ports",
 			Usage:   "Use ports instead of sockets. Defaults to true on Windows",
@@ -73,6 +88,8 @@ var CliClientOpenCommand = cli.Command{
 			LocalSocketPath:  path.Join(os.TempDir(), fmt.Sprintf("nvrh-socket-%s", sessionId)),
 
 			BrowserScriptPath: fmt.Sprintf("/tmp/nvrh-browser-%s", sessionId),
+
+			SshPath: c.String("ssh-path"),
 		}
 
 		if nvrhContext.ShouldUsePorts {

--- a/src/context/main.go
+++ b/src/context/main.go
@@ -21,6 +21,8 @@ type NvrhContext struct {
 	BrowserScriptPath string
 
 	CommandsToKill []*exec.Cmd
+
+	SshPath string
 }
 
 func (nc NvrhContext) LocalSocketOrPort() string {

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -22,7 +22,7 @@ func BuildRemoteNvimCmd(nvrhContext *context.NvrhContext) *exec.Cmd {
 	}
 
 	sshCommand := exec.Command(
-		"ssh",
+		nvrhContext.SshPath,
 		"-L",
 		tunnel,
 		"-t",
@@ -76,7 +76,7 @@ func MakeRpcTunnelHandler(nvrhContext *context.NvrhContext) func(*nvim.Nvim, []s
 			log.Printf("Tunneling %s:%s", nvrhContext.Server, args[0])
 
 			sshCommand := exec.Command(
-				"ssh",
+				nvrhContext.SshPath,
 				"-NL",
 				fmt.Sprintf("%s:0.0.0.0:%s", args[0], args[0]),
 				nvrhContext.Server,

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"log"
 	"nvrh/src/context"
-	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/neovim/go-client/nvim"
@@ -32,9 +30,7 @@ func BuildRemoteNvimCmd(nvrhContext *context.NvrhContext) *exec.Cmd {
 		fmt.Sprintf("$SHELL -i -c '%s'", nvimCommandString),
 	)
 
-	if runtime.GOOS == "windows" {
-		sshCommand.Stdout = os.Stdout
-	}
+	// sshCommand.Stdout = os.Stdout
 	// sshCommand.Stderr = os.Stderr
 	// sshCommand.Stdin = os.Stdin
 
@@ -82,9 +78,7 @@ func MakeRpcTunnelHandler(nvrhContext *context.NvrhContext) func(*nvim.Nvim, []s
 				nvrhContext.Server,
 			)
 
-			if runtime.GOOS == "windows" {
-				sshCommand.Stdout = os.Stdout
-			}
+			// sshCommand.Stdout = os.Stdout
 			// sshCommand.Stderr = os.Stderr
 			// sshCommand.Stdin = os.Stdin
 			nvrhContext.CommandsToKill = append(nvrhContext.CommandsToKill, sshCommand)

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -82,6 +82,11 @@ func MakeRpcTunnelHandler(nvrhContext *context.NvrhContext) func(*nvim.Nvim, []s
 				nvrhContext.Server,
 			)
 
+			if runtime.GOOS == "windows" {
+				sshCommand.Stdout = os.Stdout
+			}
+			// sshCommand.Stderr = os.Stderr
+			// sshCommand.Stdin = os.Stdin
 			nvrhContext.CommandsToKill = append(nvrhContext.CommandsToKill, sshCommand)
 
 			if err := sshCommand.Start(); err != nil {


### PR DESCRIPTION
Actually, turns out Windows has included OpenSSH since Windows 10 1809,  and it doesn't seem to have that `exit 255` issue.

It's even on your `PATH` by default, but Git Bash puts its path ahead of anything in Windows Registry (which is a fair play, no shade) so I didn't know it was there.

So this adds a `--ssh-path` flag, which defaults to the included OpenSSH on Windows, and `ssh` anywhere else.