### PR TITLE
fix: Dont fork ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ CATEGORY:
    client
 
 OPTIONS:
-   --ssh-path value                               Path to SSH binary. Defaults to ssh on Unix, C:\Windows\System32\OpenSSH\ssh.exe on Windows (default: "ssh") [%NVRH_CLIENT_SSH_PATH%]
-   --use-ports                                    Use ports instead of sockets. Defaults to true on Windows (default: false) [%NVRH_CLIENT_USE_PORTS%]
+   --ssh-path value                               Path to SSH binary. Defaults to ssh on Unix, C:\Windows\System32\OpenSSH\ssh.exe on Windows (default: "ssh") [$NVRH_CLIENT_SSH_PATH]
+   --use-ports                                    Use ports instead of sockets. Defaults to true on Windows (default: false) [$NVRH_CLIENT_USE_PORTS]
+   --debug                                        (default: false) [$NVRH_CLIENT_DEBUG]
    --server-env value [ --server-env value ]      Environment variables to set on the remote server
    --local-editor value [ --local-editor value ]  Local editor to use. {{SOCKET_PATH}} will be replaced with the socket path (default: "nvim", "--server", "{{SOCKET_PATH}}", "--remote-ui")
    --help, -h                                     show help

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.1
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/dusted-go/logging v1.3.0 // indirect
 	github.com/neovim/go-client v1.2.2-0.20240514170004-863141a115a5 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/urfave/cli/v2 v2.27.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0XRY=
+github.com/dusted-go/logging v1.3.0/go.mod h1:s58+s64zE5fxSWWZfp+b8ZV0CHyKHjamITGyuY1wzGg=
 github.com/neovim/go-client v1.2.1 h1:kl3PgYgbnBfvaIoGYi3ojyXH0ouY6dJY/rYUCssZKqI=
 github.com/neovim/go-client v1.2.1/go.mod h1:EeqCP3z1vJd70JTaH/KXz9RMZ/nIgEFveX83hYnh/7c=
 github.com/neovim/go-client v1.2.2-0.20240514170004-863141a115a5 h1:bDKPFxHFy0ApEmtUFFQzbxMGgywlKrpyNJ2opMX4hjc=

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"math/rand/v2"
 	"os"
 	"os/exec"
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dusted-go/logging/prettylog"
 	"github.com/neovim/go-client/nvim"
 	"github.com/urfave/cli/v2"
 
@@ -91,6 +92,17 @@ var CliClientOpenCommand = cli.Command{
 			SshPath: c.String("ssh-path"),
 		}
 
+		// Prepare the logger.
+		logLevel := slog.LevelInfo
+		log := slog.New(prettylog.New(
+			&slog.HandlerOptions{
+				Level:     logLevel,
+			},
+			prettylog.WithDestinationWriter(os.Stderr),
+			prettylog.WithColor(),
+		))
+		slog.SetDefault(log)
+
 		if nvrhContext.ShouldUsePorts {
 			min := 1025
 			max := 65535
@@ -117,10 +129,16 @@ var CliClientOpenCommand = cli.Command{
 			// clean up the remote nvim instance.
 			// exec_helpers.PrepareForForking(remoteCmd)
 
-			if err := remoteCmd.Run(); err != nil {
-				log.Printf("Error running ssh: %v", err)
+			if err := remoteCmd.Start(); err != nil {
+				slog.Error("Error starting ssh", "err", err)
+				doneChan <- err
+				return
+			}
+
+			if err := remoteCmd.Wait(); err != nil {
+				slog.Error("Error running ssh", "err", err)
 			} else {
-				log.Printf("Remote nvim exited")
+				slog.Info("Remote nvim exited")
 			}
 		}()
 
@@ -130,25 +148,31 @@ var CliClientOpenCommand = cli.Command{
 			nv, err := nvim_helpers.WaitForNvim(&nvrhContext)
 
 			if err != nil {
-				log.Printf("Error connecting to nvim: %v", err)
+				slog.Error("Error connecting to nvim", "err", err)
 				return
 			}
 
-			log.Print("Connected to nvim")
+			slog.Info("Connected to nvim")
 			nvChan <- nv
 
 			if err := prepareRemoteNvim(&nvrhContext, nv); err != nil {
-				log.Printf("Error preparing remote nvim: %v", err)
+				slog.Error("Error preparing remote nvim", "err", err)
 			}
 
 			clientCmd := BuildClientNvimCmd(&nvrhContext)
 			nvrhContext.CommandsToKill = append(nvrhContext.CommandsToKill, clientCmd)
 
-			if err := clientCmd.Run(); err != nil {
-				log.Printf("Error running local editor: %v", err)
+			if err := clientCmd.Start(); err != nil {
+				slog.Error("Error starting local editor", "err", err)
+				doneChan <- err
+				return
+			}
+
+			if err := clientCmd.Wait(); err != nil {
+				slog.Error("Error running local editor", "err", err)
 				doneChan <- err
 			} else {
-				log.Printf("Local editor exited")
+				slog.Info("Local editor exited")
 				doneChan <- nil
 			}
 		}()
@@ -158,13 +182,14 @@ var CliClientOpenCommand = cli.Command{
 		go func() {
 			select {
 			case sig := <-signalChan:
+				slog.Debug("Received signal", "signal", sig)
 				doneChan <- fmt.Errorf("Received signal: %s", sig)
 			}
 		}()
 
 		err := <-doneChan
 
-		log.Printf("Closing nvrh")
+		slog.Info("Closing nvrh")
 		closeNvimSocket(nv)
 		killAllCmds(nvrhContext.CommandsToKill)
 
@@ -182,7 +207,7 @@ func BuildClientNvimCmd(nvrhContext *context.NvrhContext) *exec.Cmd {
 		replacedArgs[i] = strings.Replace(arg, "{{SOCKET_PATH}}", nvrhContext.LocalSocketOrPort(), -1)
 	}
 
-	log.Printf("Starting local editor: %v", replacedArgs)
+	slog.Info("Starting local editor", "cmd", replacedArgs)
 
 	editorCommand := exec.Command(replacedArgs[0], replacedArgs[1:]...)
 	if replacedArgs[0] == "nvim" {
@@ -273,11 +298,11 @@ func RpcHandleOpenUrl(v *nvim.Nvim, args []string) {
 	url := args[0]
 
 	if url == "" || !(strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://")) {
-		log.Printf("Invalid url: %s", url)
+		slog.Error("Invalid url", "url", url)
 		return
 	}
 
-	log.Printf("Opening url: %s", url)
+	slog.Info("Opening url", "url", url)
 
 	if goos == "darwin" {
 		exec.Command("open", url).Run()
@@ -286,16 +311,16 @@ func RpcHandleOpenUrl(v *nvim.Nvim, args []string) {
 	} else if goos == "windows" {
 		exec.Command("cmd", "/c", "start", url).Run()
 	} else {
-		log.Printf("Don't know how to open url on %s", goos)
+		slog.Error("Don't know how to open url", "url", url)
 	}
 }
 
 func killAllCmds(cmds []*exec.Cmd) {
 	for _, cmd := range cmds {
-		log.Printf("Killing command: %v", cmd)
+		slog.Debug("Killing command", "cmd", cmd.Args)
 		if cmd.Process != nil {
 			if err := cmd.Process.Kill(); err != nil {
-				log.Printf("Error killing command: %v", err)
+				slog.Error("Error killing command", "err", err)
 			}
 		}
 	}
@@ -306,9 +331,9 @@ func closeNvimSocket(nv *nvim.Nvim) {
 		return
 	}
 
-	log.Print("Closing nvim")
+	slog.Info("Closing nvim")
 	if err := nv.ExecLua("vim.cmd('qall!')", nil, nil); err != nil {
-		log.Printf("Error closing remote nvim: %v", err)
+		slog.Error("Error closing remote nvim", "err", err)
 	}
 	nv.Close()
 }

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"nvrh/src/context"
-	"nvrh/src/exec_helpers"
 	"nvrh/src/nvim_helpers"
 	"nvrh/src/ssh_helpers"
 )
@@ -116,7 +115,7 @@ var CliClientOpenCommand = cli.Command{
 
 			// We don't want the ssh process ending too early, if it does we can't
 			// clean up the remote nvim instance.
-			exec_helpers.PrepareForForking(remoteCmd)
+			// exec_helpers.PrepareForForking(remoteCmd)
 
 			if err := remoteCmd.Run(); err != nil {
 				log.Printf("Error running ssh: %v", err)

--- a/src/context/main.go
+++ b/src/context/main.go
@@ -23,6 +23,7 @@ type NvrhContext struct {
 	CommandsToKill []*exec.Cmd
 
 	SshPath string
+	Debug   bool
 }
 
 func (nc NvrhContext) LocalSocketOrPort() string {

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -30,10 +30,6 @@ func BuildRemoteNvimCmd(nvrhContext *context.NvrhContext) *exec.Cmd {
 		fmt.Sprintf("$SHELL -i -c '%s'", nvimCommandString),
 	)
 
-	// sshCommand.Stdout = os.Stdout
-	// sshCommand.Stderr = os.Stderr
-	// sshCommand.Stdin = os.Stdin
-
 	// Create a pipe to write to the command's stdin
 	// stdinPipe, err := sshCommand.StdinPipe()
 	// if err != nil {

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -2,7 +2,7 @@ package ssh_helpers
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"nvrh/src/context"
 	"os/exec"
 	"strings"
@@ -12,7 +12,7 @@ import (
 
 func BuildRemoteNvimCmd(nvrhContext *context.NvrhContext) *exec.Cmd {
 	nvimCommandString := buildRemoteCommandString(nvrhContext)
-	log.Printf("Starting remote nvim: %s", nvimCommandString)
+	slog.Info("Starting remote nvim", "nvimCommandString", nvimCommandString)
 
 	tunnel := fmt.Sprintf("%s:%s", nvrhContext.LocalSocketPath, nvrhContext.RemoteSocketPath)
 	if nvrhContext.ShouldUsePorts {
@@ -69,7 +69,7 @@ func buildRemoteCommandString(nvrhContext *context.NvrhContext) string {
 func MakeRpcTunnelHandler(nvrhContext *context.NvrhContext) func(*nvim.Nvim, []string) {
 	return func(v *nvim.Nvim, args []string) {
 		go func() {
-			log.Printf("Tunneling %s:%s", nvrhContext.Server, args[0])
+			slog.Info("Tunneling", "server", nvrhContext.Server, "port", args[0])
 
 			sshCommand := exec.Command(
 				nvrhContext.SshPath,
@@ -84,14 +84,14 @@ func MakeRpcTunnelHandler(nvrhContext *context.NvrhContext) func(*nvim.Nvim, []s
 			nvrhContext.CommandsToKill = append(nvrhContext.CommandsToKill, sshCommand)
 
 			if err := sshCommand.Start(); err != nil {
-				log.Printf("Error starting command: %v", err)
+				slog.Error("Error starting tunnel", "err", err)
 				return
 			}
 
 			defer sshCommand.Process.Kill()
 
 			if err := sshCommand.Wait(); err != nil {
-				log.Printf("Error waiting for command: %v", err)
+				slog.Error("Error running tunnel", "err", err)
 			}
 		}()
 	}


### PR DESCRIPTION
In https://github.com/mikew/nvrh/pull/20 I changed the SSH process so it wasn't part of the process group. That was so `ctrl-c` wouldn't immediately close the SSH process and prevent nvrh from sending a command to the remote neovim instance and close it.

While that works, it also means that the password prompt isn't shown for users that don't have an SSH agent / pubkey auth. Since it only applies to `ctrl-c`, and I don't even think it works on Windows, I'm fine with disabling it until a better solution is found.

This also switches to `slog` because I need more logging levels than "print" and "fatal", and adds a `--debug` flag which shows much more output.

## Preview

When `--debug` is passed

```
[11:42:20.531] INFO: Starting remote nvim {
  "nvimCommandString": " nvim --headless --listen \"/tmp/nvrh-socket-1728830540\" --cmd \"cd Work/nvrh-demo-app\"; [ true = true ] \u0026\u0026 rm -f \"/tmp/nvrh-socket-1728830540\"",
  "source": {
    "file": "/Users/mike/Work/nvrh/src/ssh_helpers/main.go",
    "function": "nvrh/src/ssh_helpers.BuildRemoteNvimCmd",
    "line": 15
  }
}
Pseudo-terminal will not be allocated because stdin is not a terminal.
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
channel 2: open failed: connect failed: open failed
[11:42:22.311] INFO: Connected to nvim {
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.init.func1.2",
    "line": 171
  }
}
[11:42:22.458] INFO: Starting local editor {
  "cmd": [
    "/Applications/Neovide.app/Contents/MacOS/neovide",
    "--server",
    "/var/folders/09/gc_fhm_97csc0w2hlb2wmq_80000gn/T/nvrh-socket-1728830540"
  ],
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.BuildClientNvimCmd",
    "line": 232
  }
}
2024-10-13 11:42:49.822 neovide[95990:8906209] +[IMKClient subclass]: chose IMKClient_Legacy
2024-10-13 11:42:49.822 neovide[95990:8906209] +[IMKInputSession subclass]: chose IMKInputSession_Legacy
[11:42:53.394] INFO: Local editor exited {
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.init.func1.2",
    "line": 197
  }
}
[11:42:53.395] INFO: Closing nvrh {
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.init.func1",
    "line": 214
  }
}
[11:42:53.395] INFO: Closing nvim {
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.closeNvimSocket",
    "line": 369
  }
}
[11:42:53.395] ERROR: Error closing remote nvim {
  "err": "msgpack/rpc: session closed",
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.closeNvimSocket",
    "line": 371
  }
}
[11:42:53.395] DEBUG: Killing command {
  "cmd": [
    "ssh",
    "-L",
    "/var/folders/09/gc_fhm_97csc0w2hlb2wmq_80000gn/T/nvrh-socket-1728830540:/tmp/nvrh-socket-1728830540",
    "-t",
    "vscode-remote",
    "$SHELL -i -c ' nvim --headless --listen \"/tmp/nvrh-socket-1728830540\" --cmd \"cd Work/nvrh-demo-app\"; [ true = true ] \u0026\u0026 rm -f \"/tmp/nvrh-socket-1728830540\"'"
  ],
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.killAllCmds",
    "line": 355
  }
}
[11:42:53.395] DEBUG: Killing command {
  "cmd": [
    "/Applications/Neovide.app/Contents/MacOS/neovide",
    "--server",
    "/var/folders/09/gc_fhm_97csc0w2hlb2wmq_80000gn/T/nvrh-socket-1728830540"
  ],
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.killAllCmds",
    "line": 355
  }
}
[11:42:53.395] ERROR: Error killing command {
  "err": "os: process already finished",
  "source": {
    "file": "/Users/mike/Work/nvrh/src/client/main.go",
    "function": "nvrh/src/client.killAllCmds",
    "line": 358
  }
}
```

Without `--debug`

```
[11:43:32.096] INFO: Starting remote nvim {
  "nvimCommandString": " nvim --headless --listen \"/tmp/nvrh-socket-1728830612\" --cmd \"cd Work/nvrh-demo-app\"; [ true = true ] \u0026\u0026 rm -f \"/tmp/nvrh-socket-1728830612\""
}
[11:43:33.827] INFO: Connected to nvim
[11:43:33.962] INFO: Starting local editor {
  "cmd": [
    "/Applications/Neovide.app/Contents/MacOS/neovide",
    "--server",
    "/var/folders/09/gc_fhm_97csc0w2hlb2wmq_80000gn/T/nvrh-socket-1728830612"
  ]
}
[11:43:45.095] INFO: Local editor exited
[11:43:45.095] INFO: Closing nvrh
[11:43:45.095] INFO: Closing nvim
[11:43:45.095] ERROR: Error closing remote nvim {
  "err": "msgpack/rpc: session closed"
}
[11:43:45.095] ERROR: Error killing command {
  "err": "os: process already finished"
}
```