### PR TITLE
feat: Use loopback

### DIFF
--- a/src/client/main.go
+++ b/src/client/main.go
@@ -83,7 +83,7 @@ var CliClientOpenCommand = cli.Command{
 
 		// Prepare the context.
 		sessionId := fmt.Sprintf("%d", time.Now().Unix())
-		nvrhContext := context.NvrhContext{
+		nvrhContext := &context.NvrhContext{
 			SessionId:       sessionId,
 			Server:          c.Args().Get(0),
 			RemoteDirectory: c.Args().Get(1),
@@ -123,7 +123,7 @@ var CliClientOpenCommand = cli.Command{
 
 		// Prepare remote instance.
 		go func() {
-			remoteCmd := ssh_helpers.BuildRemoteNvimCmd(&nvrhContext)
+			remoteCmd := ssh_helpers.BuildRemoteNvimCmd(nvrhContext)
 			if nvrhContext.Debug {
 				remoteCmd.Stdout = os.Stdout
 				remoteCmd.Stderr = os.Stderr
@@ -161,11 +161,11 @@ var CliClientOpenCommand = cli.Command{
 			slog.Info("Connected to nvim")
 			nvChan <- nv
 
-			if err := prepareRemoteNvim(&nvrhContext, nv); err != nil {
+			if err := prepareRemoteNvim(nvrhContext, nv); err != nil {
 				slog.Error("Error preparing remote nvim", "err", err)
 			}
 
-			clientCmd := BuildClientNvimCmd(&nvrhContext)
+			clientCmd := BuildClientNvimCmd(nvrhContext)
 			if nvrhContext.Debug {
 				clientCmd.Stdout = os.Stdout
 				clientCmd.Stderr = os.Stderr

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -293,11 +293,6 @@ os.execute('chmod +x ' .. browser_script_path)
 return true
 	`, nil, nvrhContext.BrowserScriptPath, nvrhContext.RemoteSocketOrPort(), nv.ChannelID())
 
-
-
-
-
-
 	if err := batch.Execute(); err != nil {
 		return err
 	}

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -202,6 +202,7 @@ var CliClientOpenCommand = cli.Command{
 		slog.Info("Closing nvrh")
 		closeNvimSocket(nv)
 		killAllCmds(nvrhContext.CommandsToKill)
+		os.Remove(nvrhContext.LocalSocketPath)
 
 		if err != nil {
 			return err

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -149,7 +149,7 @@ var CliClientOpenCommand = cli.Command{
 		// Prepare client instance.
 		nvChan := make(chan *nvim.Nvim, 1)
 		go func() {
-			nv, err := nvim_helpers.WaitForNvim(&nvrhContext)
+			nv, err := nvim_helpers.WaitForNvim(nvrhContext)
 
 			if err != nil {
 				slog.Error("Error connecting to nvim", "err", err)

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -102,8 +102,6 @@ var CliClientOpenCommand = cli.Command{
 			Debug:   isDebug,
 		}
 
-		}
-
 		if nvrhContext.ShouldUsePorts {
 			min := 1025
 			max := 65535

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -242,8 +242,6 @@ func prepareRemoteNvim(nvrhContext *context.NvrhContext, nv *nvim.Nvim) error {
 	batch.Command(fmt.Sprintf(`let $BROWSER="%s"`, nvrhContext.BrowserScriptPath))
 
 	// Add command to tunnel port.
-	// TODO use `vim.api.nvim_create_user_command`, and check to see if the
-	// port is already mapped somehow.
 	batch.ExecLua(`
 vim.api.nvim_create_user_command(
 	'NvrhTunnelPort',

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -94,7 +94,7 @@ var CliClientOpenCommand = cli.Command{
 			ShouldUsePorts: c.Bool("use-ports"),
 
 			RemoteSocketPath: fmt.Sprintf("/tmp/nvrh-socket-%s", sessionId),
-			LocalSocketPath:  path.Join(os.TempDir(), fmt.Sprintf("nvrh-socket-%s", sessionId)),
+			LocalSocketPath:  filepath.Join(os.TempDir(), fmt.Sprintf("nvrh-socket-%s", sessionId)),
 
 			BrowserScriptPath: fmt.Sprintf("/tmp/nvrh-browser-%s", sessionId),
 

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dusted-go/logging/prettylog"
 	"github.com/neovim/go-client/nvim"
 	"github.com/urfave/cli/v2"
 
 	"nvrh/src/context"
+	"nvrh/src/logger"
 	"nvrh/src/nvim_helpers"
 	"nvrh/src/ssh_helpers"
 )
@@ -78,6 +78,9 @@ var CliClientOpenCommand = cli.Command{
 	},
 
 	Action: func(c *cli.Context) error {
+		isDebug := c.Bool("debug")
+		logger.PrepareLogger(isDebug)
+
 		// Prepare the context.
 		sessionId := fmt.Sprintf("%d", time.Now().Unix())
 		nvrhContext := context.NvrhContext{
@@ -96,23 +99,10 @@ var CliClientOpenCommand = cli.Command{
 			BrowserScriptPath: fmt.Sprintf("/tmp/nvrh-browser-%s", sessionId),
 
 			SshPath: c.String("ssh-path"),
-			Debug:   c.Bool("debug"),
+			Debug:   isDebug,
 		}
 
-		// Prepare the logger.
-		logLevel := slog.LevelInfo
-		if nvrhContext.Debug {
-			logLevel = slog.LevelDebug
 		}
-		log := slog.New(prettylog.New(
-			&slog.HandlerOptions{
-				Level:     logLevel,
-				AddSource: nvrhContext.Debug,
-			},
-			prettylog.WithDestinationWriter(os.Stderr),
-			prettylog.WithColor(),
-		))
-		slog.SetDefault(log)
 
 		if nvrhContext.ShouldUsePorts {
 			min := 1025

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -160,7 +160,7 @@ var CliClientOpenCommand = cli.Command{
 			nvChan <- nv
 
 			if err := prepareRemoteNvim(nvrhContext, nv); err != nil {
-				slog.Error("Error preparing remote nvim", "err", err)
+				slog.Warn("Error preparing remote nvim", "err", err)
 			}
 
 			clientCmd := BuildClientNvimCmd(nvrhContext)
@@ -326,7 +326,7 @@ func killAllCmds(cmds []*exec.Cmd) {
 		slog.Debug("Killing command", "cmd", cmd.Args)
 		if cmd.Process != nil {
 			if err := cmd.Process.Kill(); err != nil {
-				slog.Error("Error killing command", "err", err)
+				slog.Warn("Error killing command", "err", err)
 			}
 		}
 	}
@@ -339,7 +339,7 @@ func closeNvimSocket(nv *nvim.Nvim) {
 
 	slog.Info("Closing nvim")
 	if err := nv.ExecLua("vim.cmd('qall!')", nil, nil); err != nil {
-		slog.Error("Error closing remote nvim", "err", err)
+		slog.Warn("Error closing remote nvim", "err", err)
 	}
 	nv.Close()
 }

--- a/src/context/main.go
+++ b/src/context/main.go
@@ -26,7 +26,7 @@ type NvrhContext struct {
 	Debug   bool
 }
 
-func (nc NvrhContext) LocalSocketOrPort() string {
+func (nc *NvrhContext) LocalSocketOrPort() string {
 	if nc.ShouldUsePorts {
 		// nvim-qt, at least on Windows (and might have something to do with
 		// running in a VM) seems to prefer `127.0.0.1` to `0.0.0.0`, and I think
@@ -37,7 +37,7 @@ func (nc NvrhContext) LocalSocketOrPort() string {
 	return nc.LocalSocketPath
 }
 
-func (nc NvrhContext) RemoteSocketOrPort() string {
+func (nc *NvrhContext) RemoteSocketOrPort() string {
 	if nc.ShouldUsePorts {
 		return fmt.Sprintf("127.0.0.1:%d", nc.PortNumber)
 	}

--- a/src/context/main.go
+++ b/src/context/main.go
@@ -39,7 +39,7 @@ func (nc NvrhContext) LocalSocketOrPort() string {
 
 func (nc NvrhContext) RemoteSocketOrPort() string {
 	if nc.ShouldUsePorts {
-		return fmt.Sprintf("0.0.0.0:%d", nc.PortNumber)
+		return fmt.Sprintf("127.0.0.1:%d", nc.PortNumber)
 	}
 
 	return nc.RemoteSocketPath

--- a/src/logger/main.go
+++ b/src/logger/main.go
@@ -1,0 +1,27 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/dusted-go/logging/prettylog"
+)
+
+func PrepareLogger(isDebug bool) {
+	logLevel := slog.LevelInfo
+
+	if isDebug {
+		logLevel = slog.LevelDebug
+	}
+
+	log := slog.New(prettylog.New(
+		&slog.HandlerOptions{
+			Level:     logLevel,
+			AddSource: isDebug,
+		},
+		prettylog.WithDestinationWriter(os.Stderr),
+		prettylog.WithColor(),
+	))
+
+	slog.SetDefault(log)
+}

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -55,10 +55,12 @@ func buildRemoteCommandString(nvrhContext *context.NvrhContext) string {
 	}
 
 	return fmt.Sprintf(
-		"%s nvim --headless --listen \"%s\" --cmd \"cd %s\"",
+		"%s nvim --headless --listen \"%s\" --cmd \"cd %s\"; [ %t = true ] && rm -f \"%s\"",
 		envPairsString,
 		nvrhContext.RemoteSocketOrPort(),
 		nvrhContext.RemoteDirectory,
+		!nvrhContext.ShouldUsePorts,
+		nvrhContext.RemoteSocketPath,
 	)
 }
 

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -55,10 +55,11 @@ func buildRemoteCommandString(nvrhContext *context.NvrhContext) string {
 	}
 
 	return fmt.Sprintf(
-		"%s nvim --headless --listen \"%s\" --cmd \"cd %s\"; [ %t = true ] && rm -f \"%s\"",
+		"%s nvim --headless --listen \"%s\" --cmd \"cd %s\"; rm -f \"%s\"; [ %t = true ] && rm -f \"%s\"",
 		envPairsString,
 		nvrhContext.RemoteSocketOrPort(),
 		nvrhContext.RemoteDirectory,
+		nvrhContext.BrowserScriptPath,
 		!nvrhContext.ShouldUsePorts,
 		nvrhContext.RemoteSocketPath,
 	)

--- a/src/ssh_helpers/main.go
+++ b/src/ssh_helpers/main.go
@@ -16,7 +16,7 @@ func BuildRemoteNvimCmd(nvrhContext *context.NvrhContext) *exec.Cmd {
 
 	tunnel := fmt.Sprintf("%s:%s", nvrhContext.LocalSocketPath, nvrhContext.RemoteSocketPath)
 	if nvrhContext.ShouldUsePorts {
-		tunnel = fmt.Sprintf("%d:0.0.0.0:%d", nvrhContext.PortNumber, nvrhContext.PortNumber)
+		tunnel = fmt.Sprintf("%d:127.0.0.1:%d", nvrhContext.PortNumber, nvrhContext.PortNumber)
 	}
 
 	sshCommand := exec.Command(


### PR DESCRIPTION
When using ports instead of sockets, the Neovim port (both remote and client) are bound to the loopback address, rather than `0.0.0.0`. This should be a little more secure.

Ports tunneled via `NvrhTunnelPort` are still bound to `0.0.0.0` on the client machine, that's because I still need to use my phone / tablet to check things out sometimes, and if they were bound to `127.0.0.1` I wouldn't be able to connect. Ideally, this would be configurable at mapping-time, something like `NvrhTunnelPort 3000 interface=all` / `NvrhTunnelPort 3000 interface=loopback`

- Clean up local socket
- Clean up remote socket
- Clean up remote browser script
- Use `filepath.Join` instead of `path.Join`
- Extract logger setup