### PR TITLE
feat: Windows Host support

### DIFF
--- a/src/client/main.go
+++ b/src/client/main.go
@@ -167,7 +167,7 @@ var CliClientOpenCommand = cli.Command{
 			}
 
 			nvimCommandString := nvim_helpers.BuildRemoteCommandString(nvrhContext)
-			nvimCommandString = fmt.Sprintf("$SHELL -i -c '%s'", nvimCommandString)
+			nvimCommandString = fmt.Sprintf(`"$SHELL" -i -c '%s'`, nvimCommandString)
 			slog.Info("Starting remote nvim", "nvimCommandString", nvimCommandString)
 
 			nvrhContext.SshClient.Run(nvimCommandString, tunnelInfo)


### PR DESCRIPTION
Turns out just installing OpenSSH server via Windows' provided method just kinda works. nvrh still expects you're connecting to a unix environment, so you have to change your OpenSSH shell to Git Bash before things work, but I plan on adding support for detecting Powershell and CMD (somehow, not sure yet).

This would be much easier if nvrh was installed on both the client and server. While that was kind of the original idea (hence why the command is `nvrh client open`), I've gotten pretty far without having to do that, and would like to keep going in this direction until a feature absolutely cannot work unless `nvrh` is installed on the server.

- [x] Support Git Bash
- [ ] Support Powershell
- [ ] Support CMD

## Preview


https://github.com/user-attachments/assets/9c26b6fb-c138-4867-8432-a99128825f05

