### PR TITLE
feat: Move `cd`-ing to shell phase not vim phase

### DIFF
--- a/src/client/main.go
+++ b/src/client/main.go
@@ -171,7 +171,7 @@ var CliClientOpenCommand = cli.Command{
 			}
 
 			nvimCommandString := nvim_helpers.BuildRemoteCommandString(nvrhContext)
-			nvimCommandString = fmt.Sprintf("$SHELL -i -c '%s'", nvimCommandString)
+			nvimCommandString = fmt.Sprintf("$SHELL -i -c 'cd \"%s\" && %s'", nvrhContext.RemoteDirectory, nvimCommandString)
 			slog.Info("Starting remote nvim", "nvimCommandString", nvimCommandString)
 
 			nvrhContext.SshClient.Run(nvimCommandString, tunnelInfo)

--- a/src/nvim_helpers/main.go
+++ b/src/nvim_helpers/main.go
@@ -37,9 +37,8 @@ func BuildRemoteCommandString(nvrhContext *context.NvrhContext) string {
 	}
 
 	return fmt.Sprintf(
-		"%s nvim --headless --listen \"%s\" --cmd \"cd %s\"",
+		"%s nvim --headless --listen \"%s\"",
 		envPairsString,
 		nvrhContext.RemoteSocketOrPort(),
-		nvrhContext.RemoteDirectory,
 	)
 }


### PR DESCRIPTION
This is kinda a damned-if-you-do, damned-if-you-don't.

The reason I put it in the "vim phase" instead of the "shell phase" originally was because at work we use some ancient versions of nodejs. `cd`-ing before launching vim was interfering with some vim extensions that used nodejs, since our direnv / mise would insert itself before vim loaded. Doing the `cd` in the vim phase meant vim would start with a normal `$PATH` that hasn't been modified by project-specific direnv / mise configs, so extensions worked as expected, and any terminal started from within vim would load direnv / mise anyways, so things just worked.

Until I bumped into projects that wouldn't. I tried adding mise plugins to my nvim install, but THEN I started getting issues with rust-analyzer in a project, which would work if I started vim manually with `cd path/to/problematic-project && nvim`.

So, I'm making this change, but understand it can break things for people, and am happy to add a CLI flag + env var to let people set the behaviour. At least with this, it's exactly like if you were to `cd /some/path && nvim`, if you do use direnv / mise / etc.