### PR TITLE
feat: More env vars

### DIFF
--- a/src/client/main.go
+++ b/src/client/main.go
@@ -73,8 +73,9 @@ var CliClientOpenCommand = cli.Command{
 		},
 
 		&cli.StringSliceFlag{
-			Name:  "server-env",
-			Usage: "Environment variables to set on the remote server",
+			Name:    "server-env",
+			Usage:   "Environment variables to set on the remote server",
+			EnvVars: []string{"NVRH_CLIENT_SERVER_ENV"},
 		},
 
 		&cli.StringSliceFlag{


### PR DESCRIPTION
Since there's now 2 commands that use `--local-editor`, might be nicer for users to just be able to set one `NVRH_CLIENT_LOCAL_EDITOR` env var and have that be used everywhere.