### PR TITLE
feat: Use `nvim_set_client_info`

### DIFF
--- a/src/client/main.go
+++ b/src/client/main.go
@@ -563,7 +563,6 @@ func prepareRemoteNvim(nvrhContext *nvrh_context.NvrhContext, nv *nvim.Nvim, mod
 	case "primary":
 		allScripts = append(allScripts,
 			lua_files.ReadLuaFile("lua/init.lua"),
-			lua_files.ReadLuaFile("lua/register_local_client.lua"),
 
 			lua_files.ReadLuaFile("lua/open_url.lua"),
 			lua_files.ReadLuaFile("lua/prepare_browser_script.lua"),
@@ -575,8 +574,6 @@ func prepareRemoteNvim(nvrhContext *nvrh_context.NvrhContext, nv *nvim.Nvim, mod
 
 	case "secondary":
 		allScripts = append(allScripts,
-			lua_files.ReadLuaFile("lua/register_local_client.lua"),
-
 			lua_files.ReadLuaFile("lua/secondary_automap_ports.lua"),
 		)
 	}

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -238,35 +238,8 @@ var CliClientOpenCommand = cli.Command{
 			return fmt.Errorf("failed to connect to remote nvim: %w", err)
 		}
 
-		nv.SetClientInfo(
-			"nvrh",
-			nvim.ClientVersion{},
-			"rpc",
-			map[string]*nvim.ClientMethod{
-				"tunnel-port": {
-					Async: true,
-					NArgs: nvim.ClientMethodNArgs{
-						Min: 1,
-						Max: 1,
-					},
-				},
-
-				"open-url": {
-					Async: true,
-					NArgs: nvim.ClientMethodNArgs{
-						Min: 1,
-						Max: 1,
-					},
-				},
-			},
-			nvim.ClientAttributes{
-				"nvrh_mode":    "primary",
-				"nvrh_version": c.App.Version,
-			},
-		)
-
 		// Prepare remote nvim
-		if err := prepareRemoteNvim(nvrhContext, nv, "primary"); err != nil {
+		if err := prepareRemoteNvim(nvrhContext, nv, "primary", c.App.Version); err != nil {
 			slog.Warn("Error preparing remote nvim", "err", err)
 		}
 
@@ -484,7 +457,7 @@ var CliClientReconnectCommand = cli.Command{
 		}
 
 		// Prepare remote nvim
-		if err := prepareRemoteNvim(nvrhContext, nv, "secondary"); err != nil {
+		if err := prepareRemoteNvim(nvrhContext, nv, "secondary", c.App.Version); err != nil {
 			slog.Warn("Error preparing remote nvim", "err", err)
 		}
 
@@ -537,7 +510,34 @@ func BuildClientNvimCmd(ctx context.Context, nvrhContext *nvrh_context.NvrhConte
 	return editorCommand
 }
 
-func prepareRemoteNvim(nvrhContext *nvrh_context.NvrhContext, nv *nvim.Nvim, mode string) error {
+func prepareRemoteNvim(nvrhContext *nvrh_context.NvrhContext, nv *nvim.Nvim, mode string, version string) error {
+	nv.SetClientInfo(
+		"nvrh",
+		nvim.ClientVersion{},
+		"rpc",
+		map[string]*nvim.ClientMethod{
+			"tunnel-port": {
+				Async: true,
+				NArgs: nvim.ClientMethodNArgs{
+					Min: 1,
+					Max: 1,
+				},
+			},
+
+			"open-url": {
+				Async: true,
+				NArgs: nvim.ClientMethodNArgs{
+					Min: 1,
+					Max: 1,
+				},
+			},
+		},
+		nvim.ClientAttributes{
+			"nvrh_mode":    mode,
+			"nvrh_version": version,
+		},
+	)
+
 	nv.RegisterHandler("tunnel-port", func(v *nvim.Nvim, args []string) {
 		if _, ok := nvrhContext.TunneledPorts[args[0]]; ok {
 			return

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -238,6 +238,33 @@ var CliClientOpenCommand = cli.Command{
 			return fmt.Errorf("failed to connect to remote nvim: %w", err)
 		}
 
+		nv.SetClientInfo(
+			"nvrh",
+			nvim.ClientVersion{},
+			"rpc",
+			map[string]*nvim.ClientMethod{
+				"tunnel-port": {
+					Async: true,
+					NArgs: nvim.ClientMethodNArgs{
+						Min: 1,
+						Max: 1,
+					},
+				},
+
+				"open-url": {
+					Async: true,
+					NArgs: nvim.ClientMethodNArgs{
+						Min: 1,
+						Max: 1,
+					},
+				},
+			},
+			nvim.ClientAttributes{
+				"nvrh_mode":    "primary",
+				"nvrh_version": c.App.Version,
+			},
+		)
+
 		// Prepare remote nvim
 		if err := prepareRemoteNvim(nvrhContext, nv, "primary"); err != nil {
 			slog.Warn("Error preparing remote nvim", "err", err)

--- a/src/lua_files/lua/init.lua
+++ b/src/lua_files/lua/init.lua
@@ -8,4 +8,26 @@ _G._nvrh = {
   mapped_ports = {},
 }
 
+---@class NvrhChannelClient
+---@field name string
+---@field attributes table<string, string>
+---@field methods table<string, { NArgs: integer[], async: boolean }>
+
+---@class NvrhChannel
+---@field id integer
+---@field client NvrhChannelClient
+
+function _G._nvrh.get_nvrh_channels()
+  ---@type NvrhChannel[]
+  local channels = {}
+
+  for _, channel in ipairs(vim.api.nvim_list_chans()) do
+    if channel.client ~= nil and channel.client.name == 'nvrh' then
+      table.insert(channels, channel)
+    end
+  end
+
+  return channels
+end
+
 vim.env.NVRH_SESSION_ID = session_id

--- a/src/lua_files/lua/init.lua
+++ b/src/lua_files/lua/init.lua
@@ -1,9 +1,4 @@
 _G._nvrh = {
-  session_id = session_id,
-
-  ---@type integer[]
-  client_channels = {},
-
   ---@type { [string]: boolean }
   mapped_ports = {},
 }

--- a/src/lua_files/lua/open_url.lua
+++ b/src/lua_files/lua/open_url.lua
@@ -1,7 +1,9 @@
 ---@param url string
 function _G._nvrh.open_url(url)
-  for _, channel_id in ipairs(_G._nvrh.client_channels) do
-    pcall(vim.rpcnotify, tonumber(channel_id), "open-url", { url })
+  for _, channel in ipairs(_G._nvrh.get_nvrh_channels()) do
+    if channel.client.methods['open-url'] then
+      pcall(vim.rpcnotify, tonumber(channel.id), 'open-url', { url })
+    end
   end
 end
 

--- a/src/lua_files/lua/open_url.lua
+++ b/src/lua_files/lua/open_url.lua
@@ -7,7 +7,7 @@ function _G._nvrh.open_url(url)
   end
 end
 
-vim.api.nvim_create_user_command("NvrhOpenUrl", function(args)
+vim.api.nvim_create_user_command('NvrhOpenUrl', function(args)
   _G._nvrh.open_url(args.args)
 end, {
   nargs = 1,
@@ -16,7 +16,7 @@ end, {
 
 local original_open = vim.ui.open
 vim.ui.open = function(uri, opts)
-  if type(uri) == "string" and uri:match("^https?://") then
+  if type(uri) == 'string' and uri:match('^https?://') then
     _G._nvrh.open_url(uri)
     return nil, nil
   else

--- a/src/lua_files/lua/prepare_browser_script.lua
+++ b/src/lua_files/lua/prepare_browser_script.lua
@@ -7,5 +7,5 @@ exec nvim --server "$SOCKET_PATH" --remote-expr "v:lua._nvrh.open_url('$1')" > /
 ]]
 script_contents = string.format(script_contents, socket_path)
 
-vim.fn.writefile(vim.fn.split(script_contents, "\n"), browser_script_path)
-os.execute("chmod +x " .. browser_script_path)
+vim.fn.writefile(vim.fn.split(script_contents, '\n'), browser_script_path)
+os.execute('chmod +x ' .. browser_script_path)

--- a/src/lua_files/lua/primary_automap_ports.lua
+++ b/src/lua_files/lua/primary_automap_ports.lua
@@ -4,22 +4,22 @@ if should_map_ports then
 
     patterns = {
       -- "port 3000"
-      "port%s+(%d+)",
+      'port%s+(%d+)',
       -- "localhost:3000"
-      "localhost:(%d+)",
+      'localhost:(%d+)',
       -- "0.0.0.0:3000"
-      "%d+%.%d+%.%d+%.%d+:(%d+)",
+      '%d+%.%d+%.%d+%.%d+:(%d+)',
       -- ":3000" at start of line
-      "^:(%d+)",
+      '^:(%d+)',
       -- ":3000" but avoid eslint errors (error in foo.tsx:3)
-      "%s+:(%d+)",
+      '%s+:(%d+)',
       -- http://some.domain.com:3000 / https://some.domain.com:3000
-      "https?://[^/]+:(%d+)",
+      'https?://[^/]+:(%d+)',
     },
   }
 
   function nvrh_port_scanner.attach_port_watcher(bufnr)
-    if vim.bo[bufnr].buftype ~= "terminal" then
+    if vim.bo[bufnr].buftype ~= 'terminal' then
       return
     end
 
@@ -29,7 +29,8 @@ if should_map_ports then
     end
 
     local function on_lines(_, _, _, lastline, new_lastline, _)
-      local lines = vim.api.nvim_buf_get_lines(bufnr, lastline, new_lastline, false)
+      local lines =
+        vim.api.nvim_buf_get_lines(bufnr, lastline, new_lastline, false)
 
       for _, line in ipairs(lines) do
         for _, pattern in ipairs(nvrh_port_scanner.patterns) do
@@ -50,7 +51,7 @@ if should_map_ports then
   end
 
   -- Attach watcher on TermOpen
-  vim.api.nvim_create_autocmd("TermOpen", {
+  vim.api.nvim_create_autocmd('TermOpen', {
     callback = function(args)
       nvrh_port_scanner.attach_port_watcher(args.buf)
     end,

--- a/src/lua_files/lua/register_local_client.lua
+++ b/src/lua_files/lua/register_local_client.lua
@@ -1,1 +1,0 @@
-table.insert(_G._nvrh.client_channels, channel_id)

--- a/src/lua_files/lua/tunnel_ports.lua
+++ b/src/lua_files/lua/tunnel_ports.lua
@@ -1,7 +1,9 @@
 ---@param port string|integer
 function _G._nvrh.tunnel_port(port)
-  for _, channel_id in ipairs(_G._nvrh.client_channels) do
-    _G._nvrh._tunnel_port_with_channel(channel_id, port)
+  for _, channel in ipairs(_G._nvrh.get_nvrh_channels()) do
+    if channel.client.methods['tunnel-port'] then
+      _G._nvrh._tunnel_port_with_channel(channel_id, port)
+    end
   end
 
   if not _G._nvrh.mapped_ports[port] then

--- a/src/lua_files/lua/tunnel_ports.lua
+++ b/src/lua_files/lua/tunnel_ports.lua
@@ -14,10 +14,10 @@ end
 ---@param channel_id integer
 ---@param port string|integer
 function _G._nvrh._tunnel_port_with_channel(channel_id, port)
-  pcall(vim.rpcnotify, tonumber(channel_id), "tunnel-port", { tostring(port) })
+  pcall(vim.rpcnotify, tonumber(channel_id), 'tunnel-port', { tostring(port) })
 end
 
-vim.api.nvim_create_user_command("NvrhTunnelPort", function(args)
+vim.api.nvim_create_user_command('NvrhTunnelPort', function(args)
   _G._nvrh.tunnel_port(args.args)
 end, {
   nargs = 1,

--- a/src/lua_files/lua/tunnel_ports.lua
+++ b/src/lua_files/lua/tunnel_ports.lua
@@ -1,9 +1,7 @@
 ---@param port string|integer
 function _G._nvrh.tunnel_port(port)
   for _, channel in ipairs(_G._nvrh.get_nvrh_channels()) do
-    if channel.client.methods['tunnel-port'] then
-      _G._nvrh._tunnel_port_with_channel(channel_id, port)
-    end
+    _G._nvrh._tunnel_port_with_channel(channel.id, port)
   end
 
   if not _G._nvrh.mapped_ports[port] then
@@ -14,7 +12,15 @@ end
 ---@param channel_id integer
 ---@param port string|integer
 function _G._nvrh._tunnel_port_with_channel(channel_id, port)
-  pcall(vim.rpcnotify, tonumber(channel_id), 'tunnel-port', { tostring(port) })
+  local channel = vim.api.nvim_get_chan_info(channel_id)
+  if channel.client ~= nil and channel.client.methods['tunnel-port'] then
+    pcall(
+      vim.rpcnotify,
+      tonumber(channel_id),
+      'tunnel-port',
+      { tostring(port) }
+    )
+  end
 end
 
 vim.api.nvim_create_user_command('NvrhTunnelPort', function(args)

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,7 @@
+column_width = 80
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"


### PR DESCRIPTION
Now we can properly mark channels as being nvrh channels, so no need to track `channel_ids` anymore.

Also adds a stylua config file and formats all the lua code again