### PR TITLE
chore: Update README.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nvrh
 
-https://github.com/user-attachments/assets/aad16d20-cc78-44cd-8e9f-8412c87087eb
+https://github.com/user-attachments/assets/a7ab3f59-f931-4a47-ac28-2339d0cd25e9
 
 nvrh (Neovim Remote Helper) aims to provide a simple way of working with a
 remote Neovim instance, like you would with VSCode Remote.
@@ -84,7 +84,7 @@ nvrh client open \
 
 ### Tunneling Ports
 
-https://github.com/user-attachments/assets/4a8c302e-4e49-4f74-81a3-ac86ba33016a
+https://github.com/user-attachments/assets/f84c9fb5-f757-489d-aee5-fcdfe44317b0
 
 nvrh can tunnel ports between your local and remote machine. It does this
 either automatically by scanning the output of terminal buffers, or manually
@@ -97,7 +97,7 @@ with the `:NvrhTunnelPort` command.
 
 ### Opening URLs
 
-https://github.com/user-attachments/assets/04f9eea3-58a6-4bff-a155-8134ecdeaf2b
+https://github.com/user-attachments/assets/d6205b5d-179e-46cd-83ec-b0de278c81f6
 
 nvrh can open URLs on your local machine from your remote Neovim instance. There's a few ways to do this:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nvrh
 
-https://github.com/user-attachments/assets/a7ab3f59-f931-4a47-ac28-2339d0cd25e9
+https://github.com/user-attachments/assets/3cc9be58-ddce-4eaa-97bc-fd6ee8b0b942
 
 nvrh (Neovim Remote Helper) aims to provide a simple way of working with a
 remote Neovim instance, like you would with VSCode Remote.
@@ -84,7 +84,7 @@ nvrh client open \
 
 ### Tunneling Ports
 
-https://github.com/user-attachments/assets/f84c9fb5-f757-489d-aee5-fcdfe44317b0
+https://github.com/user-attachments/assets/6de3dfdc-d9bc-4668-be66-cbcf2071fa82
 
 nvrh can tunnel ports between your local and remote machine. It does this
 either automatically by scanning the output of terminal buffers, or manually
@@ -97,10 +97,18 @@ with the `:NvrhTunnelPort` command.
 
 ### Opening URLs
 
-https://github.com/user-attachments/assets/d6205b5d-179e-46cd-83ec-b0de278c81f6
+https://github.com/user-attachments/assets/7a0f8418-828d-4a5f-86cb-026d5d6fd182
 
 nvrh can open URLs on your local machine from your remote Neovim instance. There's a few ways to do this:
 
 - It patches `vim.ui.open`, so `gx` and `:Open https://example.com` will work.
 - It sets the `BROWSER` environment variable, so anything that runs in a Neovim terminal can open a URL.
 - It creates an `:NvrhOpenUrl` command to open a URL.
+
+### Windows Support
+
+https://github.com/user-attachments/assets/e3e542db-4858-40c6-bb90-a6f3fc642087
+
+nvrh supports Windows both locally and remote. If running on Windows, or
+if nvrh detects the remote machine is Windows, it will switch to using ports
+instead of Unix sockets.

--- a/README.md
+++ b/README.md
@@ -49,16 +49,6 @@ OPTIONS:
    --help, -h                                     show help
 ```
 
-By default it runs `nvim`, but you can run something else with
-
-```sh
-nvrh client open \
-  --local-editor nvim-qt \
-  --local-editor --nofork \
-  --local-editor --server \
-  --local-editor {{SOCKET_PATH}}
-```
-
 ### `nvrh client reconnect`
 
 Reconnect to an existing nvrh session.
@@ -82,27 +72,35 @@ OPTIONS:
    --help, -h                                     show help
 ```
 
-### `:NvrhTunnelPort`
+### Launch a different editor
+
+By default it runs `nvim`, but you can run something else with
+`--local-editor`. This example runs `nvim-qt`:
+
+```sh
+nvrh client open \
+  --local-editor nvim-qt,--nofork,--server,--local-editor,{{SOCKET_PATH}}
+```
+
+### Tunneling Ports
 
 https://github.com/user-attachments/assets/4a8c302e-4e49-4f74-81a3-ac86ba33016a
 
-nvrh adds a `:NvrhTunnelPort` command to Neovim to tunnel a port between your
-local and remote machines.
+nvrh can tunnel ports between your local and remote machine. It does this
+either automatically by scanning the output of terminal buffers, or manually
+with the `:NvrhTunnelPort` command.
 
 ```vim
 :NvrhTunnelPort 8080
 :NvrhTunnelPort 4000
 ```
 
-### `:NvrhOpenUrl`
+### Opening URLs
 
 https://github.com/user-attachments/assets/04f9eea3-58a6-4bff-a155-8134ecdeaf2b
 
-nvrh adds a `:NvrhOpenUrl` command to Neovim to open a URL on your local machine.
+nvrh can open URLs on your local machine from your remote Neovim instance. There's a few ways to do this:
 
-```vim
-:NvrhOpenUrl https://example.com
-```
-
-In addition to this command, it also sets the `BROWSER` environment variable,
-so commands can open a browser on your local machine.
+- It patches `vim.ui.open`, so `gx` and `:Open https://example.com` will work.
+- It sets the `BROWSER` environment variable, so anything that runs in a Neovim terminal can open a URL.
+- It creates an `:NvrhOpenUrl` command to open a URL.


### PR DESCRIPTION
Some new videos couldn't hurt, and the commands aren't run that often anymore. Patching `vim.ui.open` and `:Open https://...` have replace `:NvrhOpenUrl`, and `:NvrhTunnelPort` is only needed if the terminal scanner is disabled.