### PR TITLE
fix: use 127.0.0.1 instead of localhost for more compatibility

### DIFF
--- a/src/nvrh_binary_ssh/main.go
+++ b/src/nvrh_binary_ssh/main.go
@@ -91,7 +91,7 @@ func bindTunnelInfo(ti *ssh_tunnel_info.SshTunnelInfo) string {
 		return fmt.Sprintf("%s:%s", ti.LocalSocket, ti.RemoteSocket)
 	}
 
-	ip := "localhost"
+	ip := "127.0.0.1"
 	if ti.Public {
 		ip = "0.0.0.0"
 	}

--- a/src/nvrh_internal_ssh/main.go
+++ b/src/nvrh_internal_ssh/main.go
@@ -118,7 +118,7 @@ func LocalListenerFromTunnelInfo(ti *ssh_tunnel_info.SshTunnelInfo) (net.Listene
 	case "unix":
 		return net.Listen("unix", ti.LocalSocket)
 	case "port":
-		ip := "localhost"
+		ip := "127.0.0.1"
 		if ti.Public {
 			ip = "0.0.0.0"
 		}
@@ -134,7 +134,7 @@ func RemoteListenerFromTunnelInfo(ti *ssh_tunnel_info.SshTunnelInfo, sshClient *
 	case "unix":
 		return sshClient.Dial("unix", ti.RemoteSocket)
 	case "port":
-		return sshClient.Dial("tcp", fmt.Sprintf("localhost:%s", ti.RemoteSocket))
+		return sshClient.Dial("tcp", fmt.Sprintf("127.0.0.1:%s", ti.RemoteSocket))
 	}
 
 	return nil, fmt.Errorf("Invalid mode: %s", ti.Mode)

--- a/src/ssh_tunnel_info/main.go
+++ b/src/ssh_tunnel_info/main.go
@@ -16,7 +16,7 @@ func (ti *SshTunnelInfo) LocalBoundToIp() string {
 		return ti.LocalSocket
 	}
 
-	ip := "localhost"
+	ip := "127.0.0.1"
 	if ti.Public {
 		ip = "0.0.0.0"
 	}
@@ -29,7 +29,7 @@ func (ti *SshTunnelInfo) RemoteBoundToIp() string {
 		return ti.RemoteSocket
 	}
 
-	ip := "localhost"
+	ip := "127.0.0.1"
 	if ti.Public {
 		ip = "0.0.0.0"
 	}


### PR DESCRIPTION
This PR replaces `localhost` with `127.0.0.1` around SSH connection and launching Neovim. On my environment, `127.0.0.1` worked while `localhost` did not work.