### PR TITLE
feat: replace remote directory's leading tilde with HOME variable

### DIFF
--- a/src/nvim_helpers/main.go
+++ b/src/nvim_helpers/main.go
@@ -55,10 +55,19 @@ func BuildRemoteCommandString(
 		parts := []string{}
 
 		if remoteDirectory != "" {
-			parts = append(parts, fmt.Sprintf(
-				"cd '%s'",
-				remoteDirectory,
-			))
+			if after, ok := strings.CutPrefix(remoteDirectory, "~/"); ok {
+				parts = append(parts, fmt.Sprintf(
+					`Set-Location "$env:USERPROFILE\%s"`,
+					after,
+				))
+			} else if remoteDirectory == "~" {
+				parts = append(parts, `Set-Location "$env:USERPROFILE"`)
+			} else {
+				parts = append(parts, fmt.Sprintf(
+					`Set-Location "%s"`,
+					remoteDirectory,
+				))
+			}
 		}
 
 		if len(remoteEnv) > 0 {
@@ -76,10 +85,19 @@ func BuildRemoteCommandString(
 		parts := []string{}
 
 		if remoteDirectory != "" {
-			parts = append(parts, fmt.Sprintf(
-				`cd /d "%s"`,
-				remoteDirectory,
-			))
+			if after, ok := strings.CutPrefix(remoteDirectory, "~/"); ok {
+				parts = append(parts, fmt.Sprintf(
+					`cd /d "%%USERPROFILE%%\%s"`,
+					after,
+				))
+			} else if remoteDirectory == "~" {
+				parts = append(parts, `cd /d "%USERPROFILE%"`)
+			} else {
+				parts = append(parts, fmt.Sprintf(
+					`cd /d "%s"`,
+					remoteDirectory,
+				))
+			}
 		}
 
 		if len(remoteEnv) > 0 {
@@ -96,10 +114,19 @@ func BuildRemoteCommandString(
 		}
 
 		if remoteDirectory != "" {
-			parts = append(parts, fmt.Sprintf(
-				`cd /d "%s"`,
-				remoteDirectory,
-			))
+			if after, ok := strings.CutPrefix(remoteDirectory, "~/"); ok {
+				parts = append(parts, fmt.Sprintf(
+					`cd /d "%%USERPROFILE%%\%s"`,
+					after,
+				))
+			} else if remoteDirectory == "~" {
+				parts = append(parts, `cd /d "%USERPROFILE%"`)
+			} else {
+				parts = append(parts, fmt.Sprintf(
+					`cd /d "%s"`,
+					remoteDirectory,
+				))
+			}
 		}
 
 		if len(remoteEnv) > 0 {
@@ -116,7 +143,7 @@ func BuildRemoteCommandString(
 	if remoteDirectory != "" {
 		if after, ok := strings.CutPrefix(remoteDirectory, "~/"); ok {
 			parts = append(parts, fmt.Sprintf(
-				"cd \"$HOME\"'/%s'",
+				`cd "$HOME"'/%s'`,
 				after,
 			))
 		} else if remoteDirectory == "~" {

--- a/src/nvim_helpers/main.go
+++ b/src/nvim_helpers/main.go
@@ -55,11 +55,6 @@ func BuildRemoteCommandString(
 		parts := []string{}
 
 		if remoteDirectory != "" {
-			if strings.HasPrefix(remoteDirectory, "~/") {
-				remoteDirectory = strings.Replace(remoteDirectory, "~/", "$HOME/", 1)
-			} else if remoteDirectory == "~" {
-				remoteDirectory = "$HOME"
-			}
 			parts = append(parts, fmt.Sprintf(
 				"cd '%s'",
 				remoteDirectory,
@@ -119,10 +114,19 @@ func BuildRemoteCommandString(
 	parts := []string{}
 
 	if remoteDirectory != "" {
-		parts = append(parts, fmt.Sprintf(
-			`cd "%s"`,
-			remoteDirectory,
-		))
+		if after, ok := strings.CutPrefix(remoteDirectory, "~/"); ok {
+			parts = append(parts, fmt.Sprintf(
+				"cd $HOME'/%s'",
+				after,
+			))
+		} else if remoteDirectory == "~" {
+			parts = append(parts, "cd $HOME")
+		} else {
+			parts = append(parts, fmt.Sprintf(
+				"cd '%s'",
+				remoteDirectory,
+			))
+		}
 	}
 
 	parts = append(parts, fmt.Sprintf(

--- a/src/nvim_helpers/main.go
+++ b/src/nvim_helpers/main.go
@@ -116,11 +116,11 @@ func BuildRemoteCommandString(
 	if remoteDirectory != "" {
 		if after, ok := strings.CutPrefix(remoteDirectory, "~/"); ok {
 			parts = append(parts, fmt.Sprintf(
-				"cd $HOME'/%s'",
+				"cd \"$HOME\"'/%s'",
 				after,
 			))
 		} else if remoteDirectory == "~" {
-			parts = append(parts, "cd $HOME")
+			parts = append(parts, "cd \"$HOME\"")
 		} else {
 			parts = append(parts, fmt.Sprintf(
 				"cd '%s'",

--- a/src/nvim_helpers/main.go
+++ b/src/nvim_helpers/main.go
@@ -55,6 +55,11 @@ func BuildRemoteCommandString(
 		parts := []string{}
 
 		if remoteDirectory != "" {
+			if strings.HasPrefix(remoteDirectory, "~/") {
+				remoteDirectory = strings.Replace(remoteDirectory, "~/", "$HOME/", 1)
+			} else if remoteDirectory == "~" {
+				remoteDirectory = "$HOME"
+			}
 			parts = append(parts, fmt.Sprintf(
 				"cd '%s'",
 				remoteDirectory,


### PR DESCRIPTION
This PR replaces `"~/..."` and `"~"` with `$HOME`. This PR allows users to use `~/` for remote directory , as bash doesn't expand `~` in quoted section (`cd ~/my-project` works, `cd "~/my-project"` does not work)