### PR TITLE
feat: Add plugin with `:NvrhOpen` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ OPTIONS:
    --ssh-arg string [ --ssh-arg string ]            Additional arguments to pass to the SSH command [$NVRH_CLIENT_SSH_ARG]
    --enable-automap-ports                           Enable automatic port mapping (default: true) [$NVRH_CLIENT_AUTOMAP_PORTS]
    --insecure-direct-connect string                 Opens a public port on the server and connects directly to it. Use 'true' to connect to the server you're already passing
+   --use-nvim-embed                                 Whether to use --embed instead of --headless (default: false)
    --help, -h                                       show help
 ```
 
@@ -73,6 +74,31 @@ OPTIONS:
    --ssh-arg string [ --ssh-arg string ]            Additional arguments to pass to the SSH command [$NVRH_CLIENT_SSH_ARG]
    --insecure-direct-connect string                 Opens a public port on the server and connects directly to it. Use 'true' to connect to the server you're already passing
    --help, -h                                       show help
+```
+
+### `nvrh client from-neovim`
+
+```
+NAME:
+   nvrh client from-neovim - Attach a running local neovim UI to a remote nvim instance via SSH
+
+USAGE:
+   nvrh client from-neovim [options] <original-server> <server> [remote-directory]
+
+CATEGORY:
+   client
+
+OPTIONS:
+   --ssh-path string                            Path to SSH binary. 'binary' will use the default system SSH binary. 'internal' will use the internal SSH client. Anything else will be used as the path to the SSH binary [$NVRH_CLIENT_SSH_PATH] (default: "binary")
+   --use-ports                                  Use ports instead of sockets. Defaults to true on Windows [$NVRH_CLIENT_USE_PORTS] (default: false)
+   --debug                                      (default: false) [$NVRH_CLIENT_DEBUG]
+   --server-env string [ --server-env string ]  Environment variables to set on the remote server [$NVRH_CLIENT_SERVER_ENV]
+   --nvim-cmd nvim [ --nvim-cmd nvim ]          Command to run nvim with. Defaults to nvim [$NVRH_CLIENT_NVIM_CMD] (default: "nvim")
+   --ssh-arg string [ --ssh-arg string ]        Additional arguments to pass to the SSH command [$NVRH_CLIENT_SSH_ARG]
+   --enable-automap-ports                       Enable automatic port mapping (default: true) [$NVRH_CLIENT_AUTOMAP_PORTS]
+   --insecure-direct-connect string             Opens a public port on the server and connects directly to it. Use 'true' to connect to the server you're already passing
+   --use-nvim-embed                             Whether to use --embed instead of --headless (default: false)
+   --help, -h                                   show help
 ```
 
 ### Launch a different editor

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ OPTIONS:
    --help, -h                                   show help
 ```
 
+### Neovim Plugin
+
+If your Neovim UI supports `:connect`, you can add nvrh to get an `:NvrhConnect`
+command that will connect your currently running Neovim UI to a remote.
+
+```lua
+vim.pack.add({ 'https://github.com/mikew/nvrh' })
+```
+
+Then
+
+```vim
+:NvrhConnect my-remote-server path/to/project
+```
+
 ### Launch a different editor
 
 By default nvrh runs `nvim`, but you can run something else with

--- a/README.md
+++ b/README.md
@@ -107,7 +107,12 @@ If your Neovim UI supports `:connect`, you can add nvrh to get an `:NvrhConnect`
 command that will connect your currently running Neovim UI to a remote.
 
 ```lua
-vim.pack.add({ 'https://github.com/mikew/nvrh' })
+vim.pack.add({
+  {
+    src = 'https://github.com/mikew/nvrh',
+    version = vim.version.range('*'),
+  },
+})
 ```
 
 Then

--- a/plugin/nvrh.lua
+++ b/plugin/nvrh.lua
@@ -9,13 +9,6 @@ local function nvrh_connect(args)
   vim.system(cmd, { detach = true })
 end
 
-vim.api.nvim_create_user_command('NvrhOpen', function(args)
-  nvrh_connect(args.fargs)
-end, {
-  nargs = '*',
-  force = true,
-})
-
 vim.api.nvim_create_user_command('NvrhConnect', function(args)
   nvrh_connect(args.fargs)
 end, {

--- a/plugin/nvrh.lua
+++ b/plugin/nvrh.lua
@@ -1,0 +1,12 @@
+vim.api.nvim_create_user_command('NvrhOpen', function(args)
+  local cmd = { 'nvrh', 'client', 'from-neovim', vim.v.servername }
+
+  for _, arg in ipairs(args.fargs) do
+    table.insert(cmd, arg)
+  end
+
+  vim.system(cmd, { detach = true })
+end, {
+  nargs = '*',
+  force = true,
+})

--- a/plugin/nvrh.lua
+++ b/plugin/nvrh.lua
@@ -1,5 +1,20 @@
 --- @param args string[]
 local function nvrh_connect(args)
+  if _G._nvrh then
+    local hint_cmd = { 'nvrh', 'client', 'open' }
+    for _, arg in ipairs(args) do
+      table.insert(hint_cmd, arg)
+    end
+
+    vim.notify(
+      'Already connected to nvrh, please manually run `'
+        .. table.concat(hint_cmd, ' ')
+        .. '` in your terminal to start a new session.',
+      vim.log.levels.WARN
+    )
+    return
+  end
+
   local cmd = { 'nvrh', 'client', 'from-neovim', vim.v.servername }
 
   for _, arg in ipairs(args) do

--- a/plugin/nvrh.lua
+++ b/plugin/nvrh.lua
@@ -1,11 +1,23 @@
-vim.api.nvim_create_user_command('NvrhOpen', function(args)
+--- @param args string[]
+local function nvrh_connect(args)
   local cmd = { 'nvrh', 'client', 'from-neovim', vim.v.servername }
 
-  for _, arg in ipairs(args.fargs) do
+  for _, arg in ipairs(args) do
     table.insert(cmd, arg)
   end
 
   vim.system(cmd, { detach = true })
+end
+
+vim.api.nvim_create_user_command('NvrhOpen', function(args)
+  nvrh_connect(args.fargs)
+end, {
+  nargs = '*',
+  force = true,
+})
+
+vim.api.nvim_create_user_command('NvrhConnect', function(args)
+  nvrh_connect(args.fargs)
 end, {
   nargs = '*',
   force = true,


### PR DESCRIPTION
The other side of https://github.com/mikew/nvrh/pull/83. Add `mikew/nvrh` to your neovim plugins and then you can call `:NvrhOpen SERVER [DIRECTORY]`

Config is still done in `nvrh.yml`, not really sure how much this will be used because it's a new thing Neovim UIs need to handle, and the only one that does (that I've found? so far?) is neovim itself.

`nvrh` is still required to be on your `PATH`, it doesn't do any downloading. Need file signatures in releases before I'll attempt something like that.

https://github.com/neovide/neovide/issues/3469

https://github.com/equalsraf/neovim-qt/issues/1158